### PR TITLE
[#31] Input Component variant 타입 추가

### DIFF
--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -10,13 +10,14 @@ import {
 interface Props
   extends Omit<InputHTMLAttributes<HTMLInputElement>, 'onChange'> {
   value: string;
-  length: number;
+  length?: number;
+  variant?: 'standard' | 'filled' | 'outlined';
   onChange: (value: string) => void;
 }
 
 export const Input = forwardRef(
   (props: Props, ref: ForwardedRef<HTMLInputElement>) => {
-    const { value, length, onChange, ...rest } = props;
+    const { value, length, variant = 'standard', onChange, ...rest } = props;
 
     const changeHandler = (e: ChangeEvent<HTMLInputElement>) => {
       const newValue = e.target.value.slice(0, length);
@@ -28,12 +29,12 @@ export const Input = forwardRef(
         css={{
           width: '100%',
           padding: '0 18px',
-          border: 'none',
           color: 'dimgrey',
           fontSize: '40px',
           '&:focus': {
             outline: 'none',
           },
+          ...TYPE_VARIANTS[variant],
         }}
         type='text'
         value={value}
@@ -44,3 +45,25 @@ export const Input = forwardRef(
     );
   }
 );
+
+const TYPE_VARIANTS = {
+  standard: {
+    border: 'none',
+    outline: 'none',
+  },
+  filled: {
+    backgroundColor: '#e9e9e9',
+    border: 'none',
+    borderRadius: '8px',
+    transition: 'background .2s ease, color .1s ease, box-shadow .2s ease',
+    boxShadow: 'none',
+  },
+  outlined: {
+    padding: '10px',
+    outline: 'none',
+    border: 'none',
+    borderRadius: '8px',
+    transition: `background .2s ease,color .1s ease, box-shadow .2s ease`,
+    boxShadow: `inset 0 0 0 4px #e9e9e9`,
+  },
+};


### PR DESCRIPTION
```
const TYPE_VARIANTS = {
  standard: {
    border: 'none',
    outline: 'none',
  },
  filled: {
    backgroundColor: '#e9e9e9',
    border: 'none',
    borderRadius: '8px',
    transition: 'background .2s ease, color .1s ease, box-shadow .2s ease',
    boxShadow: 'none',
  },
  outlined: {
    padding: '10px',
    outline: 'none',
    border: 'none',
    borderRadius: '8px',
    transition: `background .2s ease,color .1s ease, box-shadow .2s ease`,
    boxShadow: `inset 0 0 0 4px #e9e9e9`,
  },
};
```

해당 스타일을 추가 하였습니다.

#### standard
<img width="401" alt="image" src="https://github.com/subin1224/Simple-brain-training/assets/76253952/350b63a4-44a3-4e95-83b6-af8ac2bab1b8">
default 값 입니다.
밑줄 없는 기본 `input > textfield` 으로 지정해두었습니다.

#### filled
<img width="408" alt="image" src="https://github.com/subin1224/Simple-brain-training/assets/76253952/4dcb973f-4635-46eb-a80c-c2447d08dccd">
배경화면이 채워져있는 스타일 입니다.

#### outlined
<img width="400" alt="image" src="https://github.com/subin1224/Simple-brain-training/assets/76253952/960eaece-cabd-4a4f-91ac-000c59d77a47">
테두리가 있는 스타일 입니다.

